### PR TITLE
docs: update stack readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,28 @@
 
 This repository contains the declarative configuration for my **self-hosted home media environment**, deployed on a single-node [**K3s**](https://k3s.io/) Kubernetes cluster running on Ubuntu 24.04 Server.
 
-Each application is either deployed using **Helm** (e.g. official Helm charts or other reputable charts) or raw Kubernetes manifests under [`apps/`](./apps). This setup enables reproducible, declarative, and modular deployments — all isolated to my LAN.
+Each application is either deployed using **Helm** (e.g. official Helm charts or other reputable charts) or raw Kubernetes manifests under [`apps/`](./apps) and [`utils/`](./utils). This setup enables reproducible, declarative, and modular deployments — all isolated to my LAN.
 
 ---
 
 ## 📦 Stack Overview
 
-| App                                                                                          | Purpose                                                  | Deployment Type        | Config Path                                      | Migrated/Implemented |
-|-----------------------------------------------------------------------------------------------|----------------------------------------------------------|-------------------------|--------------------------------------------------|-----------------------|
-| [Bazarr](https://www.bazarr.media/)                                                           | Subtitle downloader                                      | Raw Manifests           | [`apps/bazarr`](./apps/bazarr)                   | ✅                    |
-| [Sonarr](https://sonarr.tv/)                                                                  | TV episode automation                                    | Official Helm Chart     | [`apps/sonarr`](./apps/sonarr)                   | ❌                    |
-| [Radarr](https://radarr.video/)                                                               | Movie automation                                         | Official Helm Chart     | [`apps/radarr`](./apps/radarr)                   | ❌                    |
-| [qBittorrent](https://www.qbittorrent.org/)                                                   | Torrent client (headless)                               | Official Helm Chart     | [`apps/qbittorrent`](./apps/qbittorrent)         | ❌                    |
-| [Prowlarr](https://wiki.servarr.com/prowlarr)                                                 | Indexer manager                                         | Official Helm Chart     | [`apps/prowlarr`](./apps/prowlarr)               | ❌                    |
-| [Jellyseerr](https://github.com/Fallenbagel/jellyseerr)                                       | Media request interface                                 | Raw Manifests           | [`apps/jellyseerr`](./apps/jellyseerr)           | ✅                    |
-| [Profilarr](https://github.com/saswatds/profilarr)                                            | Quality profile sync                                    | Raw Manifests           | [`apps/profilarr`](./apps/profilarr)             | ✅                    |
-| [Homarr](https://github.com/ajnart/homarr)                                                    | Home dashboard                                          | Raw Manifests           | [`apps/homarr`](./apps/homarr)                   | ✅                    |
-| [Kubernetes Dashboard](https://github.com/kubernetes/dashboard)                               | Dashboard for K8s                                       | Raw Manifests           | [`apps/kubernetes-dashboard`](./apps/kubernetes-dashboard) | ✅          |
-| [Dashdot](https://github.com/MauriceNino/dashdot)                                             | Node metrics dashboard (used in Homarr)                 | Raw Manifests           | [`apps/dashdot`](./apps/dashdot)                 | ✅                    |
-| [Speedtest Tracker](https://github.com/henrywhitaker3/Speedtest-Tracker)                     | Internet speed monitor                                  | `soblivionscall` Helm Chart | [`utils/speedtest-tracker`](./apps/speedtest-tracker) | ✅             |
-| [Tdarr](https://github.com/HaveAGitGat/Tdarr)                                                 | Conditional media transcoding/remuxing                  | `haveagitgat` Helm Chart    | [`apps/tdarr`](./apps/tdarr)                     |  ✅                   |
-| [yt-dlp-webui](https://github.com/MaxelAmador/yt-dlp-web-ui)                                 | Download videos using yt-dlp with a Web UI              | Raw Manifests     | [`utils/yt-dlp-webui`](./apps/yt-dlp-webui)       | ✅                    |
-| [Watchtower](https://containrrr.dev/watchtower/)                                              | Automatic container update watcher                      | TBC     | [`apps/watchtower`](./apps/watchtower)           | ❌                    |
+| App                                                                                          | Purpose                          | Deployment Type               | Config Path                                | Migrated/Implemented |
+|-----------------------------------------------------------------------------------------------|----------------------------------|-------------------------------|--------------------------------------------|----------------------|
+| [Bazarr](https://www.bazarr.media/)                                                           | Subtitle downloader              | Raw Manifests                 | [`apps/bazarr`](./apps/bazarr)             | ✅ |
+| [Sonarr](https://sonarr.tv/)                                                                  | TV episode automation   | Official Helm Chart           | [`apps/sonarr`](./apps/sonarr)             | ❌ |
+| [Radarr](https://radarr.video/)                                                               | Movie automation   | Official Helm Chart           | [`apps/radarr`](./apps/radarr)             | ❌ |
+| [qBittorrent](https://www.qbittorrent.org/)                                                   | Torrent client (headless)   | Official Helm Chart           | [`apps/qbittorrent`](./apps/qbittorrent)   | ❌ |
+| [Prowlarr](https://wiki.servarr.com/prowlarr)                                                 | Indexer manager   | Official Helm Chart           | [`apps/prowlarr`](./apps/prowlarr)         | ❌ |
+| [ErsatzTV](https://ersatztv.org/)                                                             | Virtual live TV channels         | Raw Manifests                 | [`apps/ersatztv`](./apps/ersatztv)         | ✅ |
+| [Jellyseerr](https://github.com/Fallenbagel/jellyseerr)                                       | Media request interface          | Raw Manifests                 | [`apps/jellyseerr`](./apps/jellyseerr)     | ✅ |
+| [Profilarr](https://github.com/saswatds/profilarr)                                            | Quality profile sync             | Raw Manifests                 | [`apps/profilarr`](./apps/profilarr)       | ✅ |
+| [Homarr](https://github.com/ajnart/homarr)                                                    | Home dashboard                   | Raw Manifests                 | [`apps/homarr`](./apps/homarr)             | ✅ |
+| [Kubernetes Dashboard](https://github.com/kubernetes/dashboard)                               | Dashboard for K8s                | Raw Manifests                 | [`apps/kubernetes-dashboard`](./apps/kubernetes-dashboard) | ✅ |
+| [Dashdot](https://github.com/MauriceNino/dashdot)                                             | Node metrics dashboard (used in Homarr) | Raw Manifests         | [`apps/dashdot`](./apps/dashdot)           | ✅ |
+| [Speedtest Tracker](https://github.com/henrywhitaker3/Speedtest-Tracker)                     | Internet speed monitor           | `soblivionscall` Helm Chart   | [`utils/speedtest-tracker`](./utils/speedtest-tracker) | ✅ |
+| [Tdarr](https://github.com/HaveAGitGat/Tdarr)                                                 | Conditional media transcoding/remuxing | `haveagitgat` Helm Chart | [`apps/tdarr`](./apps/tdarr)               | ✅ |
+| [yt-dlp-webui](https://github.com/MaxelAmador/yt-dlp-web-ui)                                 | Download videos using yt-dlp with a Web UI | Raw Manifests        | [`utils/yt-dlp`](./utils/yt-dlp)           | ✅ |
 
 ---
 
@@ -36,17 +36,26 @@ This is a work in progress. My current non-Kubernetes setup works. Some services
 ## 🗂 Directory Structure
 
 ```bash
-meyuflix-helm/
+meyuflix/
 ├── apps/
-│   ├── bazarr/             # Raw manifests (Deployment, Service, Ingress, PV/PVC)
-│   ├── profilarr/          # Same structure as bazarr
-│   ├── jellyseerr/         # Same structure as bazarr
-│   ├── sonarr/             # Helm values.yaml (TBC)
-│   ├── radarr/             # Helm values.yaml (TBC)
-│   ├── speedtest-tracker/  # Helm values.yaml (soblivionscall)
-│   ├── tdarr/              # Helm values.yaml (TBC)
-│   ├── yt-dlp-webui/       # Helm values.yaml (TBC)
-│   ├── watchtower/         # Helm values.yaml (TBC)
+│   ├── bazarr/                 # Raw manifests (Deployment, Service, Ingress, PV/PVC)
+│   ├── dashdot/                # Raw manifests
+│   ├── ersatztv/               # Raw manifests
+│   ├── homarr/                 # Raw manifests
+│   ├── jellyseerr/             # Raw manifests
+│   ├── kubernetes-dashboard/   # Raw manifests
+│   ├── profilarr/              # Raw manifests
+│   ├── prowlarr/               # Helm values.yaml (TBC)
+│   ├── qbittorrent/            # Helm values.yaml (TBC)
+│   ├── radarr/                 # Helm values.yaml (TBC)
+│   ├── sonarr/                 # Helm values.yaml (TBC)
+│   └── tdarr/                  # Helm values + manifests
+├── namespaces/
+│   ├── apps-namespace.yaml
+│   └── utils-namespace.yaml
+├── utils/
+│   ├── speedtest-tracker/      # Helm values.yaml (soblivionscall)
+│   └── yt-dlp/                 # Raw manifests
 └── README.md
 ```
 
@@ -56,13 +65,26 @@ meyuflix-helm/
 
 ### 🔹 Helm-Based Apps
 
-For Sonarr, Radarr, etc. (official charts):
+For Sonarr, Radarr, qBittorrent, and Prowlarr (official charts):
 
 ```bash
 helm repo add arr-dev https://arr-dev.github.io/charts/
 helm repo update
 
-helm upgrade --install sonarr arr-dev/sonarr   --namespace apps --create-namespace   -f apps/sonarr/values.yaml
+helm upgrade --install sonarr arr-dev/sonarr \
+  --namespace apps --create-namespace \
+  -f apps/sonarr/values.yaml
+```
+
+For Tdarr:
+
+```bash
+helm repo add haveagitgat https://haveagitgat.github.io/helm-charts/
+helm repo update
+
+helm upgrade --install tdarr haveagitgat/tdarr \
+  --namespace apps --create-namespace \
+  -f apps/tdarr/values.yaml
 ```
 
 For Speedtest Tracker:
@@ -71,12 +93,13 @@ For Speedtest Tracker:
 helm repo add soblivionscall https://soblivionscall.github.io/charts/
 helm repo update
 
-helm upgrade --install speedtest-tracker soblivionscall/speedtest-tracker   --namespace apps --create-namespace   -f apps/speedtest-tracker/values.yaml
+helm upgrade --install speedtest-tracker soblivionscall/speedtest-tracker \
+  --namespace utils --create-namespace \
+  -f utils/speedtest-tracker/values.yaml
 ```
-
 ### 🔹 Raw Manifest Apps
 
-For Bazarr, Jellyseerr, Profilarr, etc., apply their YAMLs manually:
+For Bazarr, ErsatzTV, Homarr, Jellyseerr, Profilarr, Dashdot, Kubernetes Dashboard, etc., apply their YAMLs manually:
 
 ```bash
 kubectl apply -f apps/bazarr/
@@ -100,7 +123,7 @@ All services are locked to my LAN behind strict firewall rules. K3s is configure
 ## 🧪 Notes
 
 - Most persistent apps use `hostPath` volumes bound to directories like `/opt/<app>/config`
-- Apps are deployed in the `apps` namespace
+- Applications run in the `apps` namespace, with supporting tools in `utils`
 - Work is underway to migrate remaining services from Docker Compose to K3s
 - Future additions may use `Helmfile` for full-stack orchestration
 


### PR DESCRIPTION
## Summary
- restore placeholders for Sonarr, Radarr, qBittorrent, and Prowlarr while adding ErsatzTV
- expand directory tree and Helm deployment examples for planned apps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c44e0d40f08329a465a9b3bdc27783