### PR TITLE
Add Agregarr deployment manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each application is either deployed using **Helm** (e.g. official Helm charts or
 | [ErsatzTV](https://ersatztv.org/)                                                             | Virtual live TV channels         | Raw Manifests                 | [`apps/ersatztv`](./apps/ersatztv)         | ✅ |
 | [Jellyseerr](https://github.com/Fallenbagel/jellyseerr)                                       | Media request interface          | Raw Manifests                 | [`apps/jellyseerr`](./apps/jellyseerr)     | ✅ |
 | [Profilarr](https://github.com/saswatds/profilarr)                                            | Quality profile sync             | Raw Manifests                 | [`apps/profilarr`](./apps/profilarr)       | ✅ |
+| [Agregarr](https://github.com/agregarr/agregarr)                                              | Unified media aggregator           | Raw Manifests                 | [`apps/agregarr`](./apps/agregarr)       | ✅ |
 | [Homarr](https://github.com/ajnart/homarr)                                                    | Home dashboard                   | Raw Manifests                 | [`apps/homarr`](./apps/homarr)             | ✅ |
 | [Kubernetes Dashboard](https://github.com/kubernetes/dashboard)                               | Dashboard for K8s                | Raw Manifests                 | [`apps/kubernetes-dashboard`](./apps/kubernetes-dashboard) | ✅ |
 | [Dashdot](https://github.com/MauriceNino/dashdot)                                             | Node metrics dashboard (used in Homarr) | Raw Manifests         | [`apps/dashdot`](./apps/dashdot)           | ✅ |
@@ -38,6 +39,7 @@ This is a work in progress. My current non-Kubernetes setup works. Some services
 ```bash
 meyuflix/
 ├── apps/
+│   ├── agregarr/               # Raw manifests
 │   ├── bazarr/                 # Raw manifests (Deployment, Service, Ingress, PV/PVC)
 │   ├── dashdot/                # Raw manifests
 │   ├── ersatztv/               # Raw manifests

--- a/apps/agregarr/agregarr-deployment.yaml
+++ b/apps/agregarr/agregarr-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agregarr
+  namespace: apps
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agregarr
+  template:
+    metadata:
+      labels:
+        app: agregarr
+    spec:
+      containers:
+        - name: agregarr
+          image: ghcr.io/agregarr/agregarr:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: TZ
+              value: "Asia/Jerusalem"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: agregarr-config-claim

--- a/apps/agregarr/agregarr-ingress.yaml
+++ b/apps/agregarr/agregarr-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: agregarr
+  namespace: apps
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: agregarr.home
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: agregarr
+                port:
+                  number: 3000

--- a/apps/agregarr/agregarr-pv.yaml
+++ b/apps/agregarr/agregarr-pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: agregarr-config-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: "/opt/agregarr/config"

--- a/apps/agregarr/agregarr-pvc.yaml
+++ b/apps/agregarr/agregarr-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agregarr-config-claim
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/agregarr/agregarr-service.yaml
+++ b/apps/agregarr/agregarr-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agregarr
+  namespace: apps
+spec:
+  selector:
+    app: agregarr
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add raw Kubernetes manifests for Agregarr
- document Agregarr in project overview and directory structure

## Testing
- `kubectl apply --dry-run=client -f apps/agregarr/` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `yamllint apps/agregarr` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81c6b7660832982297d41ecef5305