### PR TITLE
Add Agregarr manifests with correct ports

### DIFF
--- a/apps/agregarr/agregarr-deployment.yaml
+++ b/apps/agregarr/agregarr-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agregarr
+  namespace: apps
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agregarr
+  template:
+    metadata:
+      labels:
+        app: agregarr
+    spec:
+      containers:
+        - name: agregarr
+          image: ghcr.io/linuxserver/agregarr:latest
+          ports:
+            - containerPort: 7171
+          env:
+            - name: PUID
+              value: "1000"
+            - name: PGID
+              value: "1000"
+            - name: TZ
+              value: "Asia/Jerusalem"

--- a/apps/agregarr/agregarr-ingress.yaml
+++ b/apps/agregarr/agregarr-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: agregarr
+  namespace: apps
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: agregarr.home
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: agregarr
+                port:
+                  number: 7171
+

--- a/apps/agregarr/agregarr-service.yaml
+++ b/apps/agregarr/agregarr-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agregarr
+  namespace: apps
+spec:
+  type: ClusterIP
+  selector:
+    app: agregarr
+  ports:
+    - port: 7171
+      targetPort: 7171
+


### PR DESCRIPTION
## Summary
- add Agregarr deployment exposing container port 7171
- expose service and ingress on port 7171 targeting the container

## Testing
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y kubectl` *(fails: package not found)*
- `kubectl apply -f apps/agregarr` *(fails: command not found)*
- `curl -I http://agregarr.home` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c8213b37648329a80dd93c284397d7