### PR TITLE
yt2radarr: add TV hostPath and rename media-volume to movie-volume

### DIFF
--- a/apps/yt2radarr/yt2radarr-deployment.yaml
+++ b/apps/yt2radarr/yt2radarr-deployment.yaml
@@ -51,8 +51,12 @@ spec:
           mountPath: /config
 
         # Radarr's movie library from the node
-        - name: media-volume
+        - name: movie-volume
           mountPath: /mnt/Movies
+
+        # TV library from the node
+        - name: tv-volume
+          mountPath: /mnt/TV Shows
 
         # Secret with your exported YouTube cookies (read-only)
         - name: yt-cookies
@@ -66,9 +70,15 @@ spec:
           claimName: yt2radarr-config-claim
 
       # hostPath that matches Radarr's library path
-      - name: media-volume
+      - name: movie-volume
         hostPath:
           path: /mnt/Movies
+          type: Directory
+
+      # hostPath that matches TV library path
+      - name: tv-volume
+        hostPath:
+          path: /mnt/TV Shows
           type: Directory
 
       # Secret containing youtube_cookies.txt
@@ -80,4 +90,3 @@ spec:
             path: cookies.txt
           # world-readable in the pod so we can cp it as non-root
           defaultMode: 0444
-


### PR DESCRIPTION
### Motivation
- Separate movie and TV host mounts so the container can access Radarr's movie library and the TV library on the node as distinct volumes.
- Clarify naming by renaming the generic `media-volume` to `movie-volume` to reflect its purpose.

### Description
- Renamed `media-volume` to `movie-volume` in both `volumeMounts` and `volumes` and kept its `hostPath` at `/mnt/Movies`.
- Added a new `tv-volume` `volumeMount` and `volume` pointing to the host path `/mnt/TV Shows` to expose the TV library into the pod.
- Kept the existing config PVC and `yt-cookies` secret mount intact and unchanged.

### Testing
- Validated the manifest with `kubectl apply --dry-run=client -f apps/yt2radarr/yt2radarr-deployment.yaml`, which completed successfully.
- Linted and schema-validated the YAML with `kubeval apps/yt2radarr/yt2radarr-deployment.yaml`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5903932e083299fb5a0bf3d8a6f4a)